### PR TITLE
Add changes (Formatting #3 / Sorta #4)

### DIFF
--- a/src/formatter.py
+++ b/src/formatter.py
@@ -249,10 +249,8 @@ class FormatterSourceGenerator(SourceGenerator):
         self.statement(node, "if ", node.test, ":")
 
         if len(node.body) == 1 and isinstance(node.body[0], ast.Expr):
-            self.write(" ")
             self.visit(node.body[0].value)
         else:
-            self.write(" ")
             for i, stmt in enumerate(node.body):
                 if i > 0:
                     self.write("; ")
@@ -268,11 +266,10 @@ class FormatterSourceGenerator(SourceGenerator):
             elif else_:
                 self.newline = old_newline
                 self.write(self.newline, "else:")
-                self.write(" ")
                 self.newline = lambda node=None: ''
                 for i, stmt in enumerate(else_):
                     if i > 0:
-                        self.write("; ")
+                        self.write(";")
                     self.visit(stmt)
                 break
             else:

--- a/src/formatter.py
+++ b/src/formatter.py
@@ -242,19 +242,44 @@ class FormatterSourceGenerator(SourceGenerator):
             self.newline()
 
     def visit_If(self, node):
+        old_newline = self.newline
+        self.newline = lambda node=None: ''
+
         set_precedence(node, node.test)
         self.statement(node, "if ", node.test, ":")
-        self.body(node.body)
+
+        if len(node.body) == 1 and isinstance(node.body[0], ast.Expr):
+            self.write(" ")
+            self.visit(node.body[0].value)
+        else:
+            self.write(" ")
+            for i, stmt in enumerate(node.body):
+                if i > 0:
+                    self.write("; ")
+                self.visit(stmt)
+
         while True:
             else_ = node.orelse
             if len(else_) == 1 and isinstance(else_[0], ast.If):
                 node = else_[0]
                 set_precedence(node, node.test)
                 self.write(self.newline, "elif ", node.test, ":")
-                self.body(node.body)
-            else:
-                self.else_body(else_)
+                self.visit(node.body[0])
+            elif else_:
+                self.newline = old_newline
+                self.write(self.newline, "else:")
+                self.write(" ")
+                self.newline = lambda node=None: ''
+                for i, stmt in enumerate(else_):
+                    if i > 0:
+                        self.write("; ")
+                    self.visit(stmt)
                 break
+            else:
+                break
+
+        self.newline = old_newline
+
 
     def visit_For(self, node, is_async=False):
         set_precedence(node, node.target)

--- a/src/main.py
+++ b/src/main.py
@@ -15,3 +15,4 @@ source = to_source(
 print(source)
 with open(argv[1][:-3] + "_new.py", "w") as f:
     f.write(source)
+

--- a/src/tempCodeRunnerFile.py
+++ b/src/tempCodeRunnerFile.py
@@ -1,0 +1,4 @@
+gen = FormatterSourceGenerator(indent_with=' ')
+ast_node = parse('if x: print(x)\nelse: print(x)')
+gen.visit(ast_node)
+print(''.join(gen.result))


### PR DESCRIPTION
## Description

This PR removes the extra newline after statements with a single thing in their body (e.g. `if x:b` instead of `if x:<NEWLINE>b`), as described in the linked issue. Additionally, multi-line statements are now separated by a semicolon `;` instead of a newline.

## Changes Made
The `visit_If` method in `formatter.py` was modified to remove the extra newline after a single statement in the body of an `if` block.

### What this completes

- [x] Removed extra newline after statements with a single thing in their body (e.g. `if x:b` instead of `if x:<NEWLINE>b`)
- [ ] Prevent extra new lines (particularly for things in parentheses)
- [ ] Remove any spaces around parentheses
- [ ] Replace all possible newlines with `;`. This will likely require extended AST analysis (could be *future* category)
- [ ] Remove spacing around string literals if possible
- [ ] Merge imports into one line
- [ ] Remove type annotations
- [ ] Rename all variables to `a`, `b`, `c`, etc. (This *could* be implemented in Formatting, but likely *shouldn't*)
- [ ] Assign builtins used multiple times to a variable (e.g. `a, b = range(5), range(3)` becomes `r=range;a,b=r(5),r(3)`)
- [ ] **⚠ BLOCKER: Add the ability to manipulate the AST before converting**
- [ ] "Danger" Mode (allow certain shortens that might harm code execution)
  - [ ] Change all imports to star imports
  - [ ] Remove `assert` statements
- [ ] Switch to a custom AST-based converter with less limitations from SourceGenerator
  - [ ] This could also free us from the 3-Clause BSD if we wanted to use Unlicense or MIT

